### PR TITLE
ci: use Rust 1.85 for building release binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2 # Fail cache download after 2 minutes.
+  # Remember to update RUST_VERSION in release.yml when updating this value.
   RUST_VERSION: '1.85'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 10.9
   # Emit backtraces on panics.
   RUST_BACKTRACE: 1
+  RUST_VERSION: '1.85'
 
 jobs:
   github_build:
@@ -102,7 +103,7 @@ jobs:
       - name: Setup | Rust
         uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # v1
         with:
-          toolchain: 1.77
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
 
       - name: Setup | Cross


### PR DESCRIPTION
This is a follow-up for #677
