### PR TITLE
fix: Linux builds

### DIFF
--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -2,7 +2,7 @@ ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
 RUN rm -rf /usr/local/go
-RUN curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN curl -L https://go.dev/dl/go1.22.12.linux-amd64.tar.gz | tar -xz -C /usr/local
 
 ENV PATH /usr/local/go/bin:$PATH
 # Verify that `go` is in the path


### PR DESCRIPTION
Fixes regression introduced by #668 by upgrading golang toolchain version from `v1.20` to `v1.22` as expected by `rusty-lassie`. 

Related to #691 
Partially closes #689 