### PR TITLE
docs: Specify rust and go versions in docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,9 +33,6 @@ If you have Rust tooling installed on your machine (see
 [Install Rust](https://www.rust-lang.org/tools/install)), you can build & install Zinnia from the
 source code.
 
-In addition to the Rust build toolchain, you also need Go installed. See
-[Go Downloads](https://go.dev/dl/). The minimum required version of Go is 1.22.
-
 **Rust version requirement:** Zinnia requires Rust toolchain version 1.77. If you have `rustup`
 installed, you can install this specific version using:
 
@@ -43,6 +40,9 @@ installed, you can install this specific version using:
 rustup install 1.77
 rustup default 1.77
 ```
+
+In addition to the Rust build toolchain, you also need Go installed. See
+[Go Downloads](https://go.dev/dl/). The minimum required version of Go is 1.22.
 
 On Windows, Go uses `gcc` to create C libraries. Go recommends installing
 [TDM GCC](https://jmeubank.github.io/tdm-gcc/).

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,8 +36,8 @@ source code.
 In addition to the Rust build toolchain, you also need Go installed. See
 [Go Downloads](https://go.dev/dl/). The minimum required version of Go is 1.22.
 
-**Rust version requirement:** Zinnia requires Rust toolchain version 1.77. If you have 
-`rustup` installed, you can install this specific version using:
+**Rust version requirement:** Zinnia requires Rust toolchain version 1.77. If you have `rustup`
+installed, you can install this specific version using:
 
 ```sh
 rustup install 1.77

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,15 @@ If you have Rust tooling installed on your machine (see
 source code.
 
 In addition to the Rust build toolchain, you also need Go installed. See
-[Go Downloads](https://go.dev/dl/).
+[Go Downloads](https://go.dev/dl/). The minimum required version of Go is 1.22.
+
+**Rust version requirement:** Zinnia requires Rust toolchain version 1.77. If you have 
+`rustup` installed, you can install this specific version using:
+
+```sh
+rustup install 1.77
+rustup default 1.77
+```
 
 On Windows, Go uses `gcc` to create C libraries. Go recommends installing
 [TDM GCC](https://jmeubank.github.io/tdm-gcc/).


### PR DESCRIPTION
This pull request updates the `cli/README.md` file to specify the required versions of Go and Rust for building the project.


Closes #693 