### PR TITLE
ci: run CI on push to any branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ name: Continuous integration
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I noticed that GitHub is not running the `ci.yaml` workflow for new commits pushed to the `main` branch. In this PR, I am removing the branch restriction from the trigger config.
