### PR TITLE
ci: run macos tests on aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         target:
           - triple: x86_64-apple-darwin
-            os: macos-14
+            os: macos-13
           - triple: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
           - triple: x86_64-pc-windows-msvc
             os: windows-latest
           - triple: x86_64-unknown-linux-gnu
@@ -62,7 +62,7 @@ jobs:
       matrix:
         release-mode: [false, true]
         target:
-          - triple: "x86_64-apple-darwin"
+          - triple: "aarch64-apple-darwin"
             os: macos-latest
           - triple: "x86_64-pc-windows-msvc"
             os: windows-latest


### PR DESCRIPTION
macos-latest (macos-14) is running on Apple Silicon. When we cross-compile to `x86_64`, the build takes longer to complet and is failing in #717.

I don't have the apetite to dig deeper to find the root cause, changing the runner images used by build and test steps is the easiest fix.
