### PR TITLE
test: add tests for new Web Platform APIs

### DIFF
--- a/runtime/tests/js/fetch_tests.js
+++ b/runtime/tests/js/fetch_tests.js
@@ -38,3 +38,8 @@ test("Response", async () => {
   const response = new Response();
   await response.arrayBuffer();
 });
+
+test("Response.bytes()", async () => {
+  const response = new Response();
+  await response.bytes();
+});

--- a/runtime/tests/js/webapis_tests.js
+++ b/runtime/tests/js/webapis_tests.js
@@ -28,3 +28,24 @@ test("URL", () => {
   const url = new URL("https://filstation.app");
   assertEquals(url.host, "filstation.app");
 });
+
+test("URL.parse()", () => {
+  // Testcases from https://developer.mozilla.org/en-US/docs/Web/API/URL/parse_static
+
+  // Relative reference to a valid base URL
+  assertEquals(
+    URL.parse("en-US/docs", "https://developer.mozilla.org")?.href,
+    "https://developer.mozilla.org/en-US/docs",
+  );
+
+  // Invalid base URL (missing colon)
+  assertEquals(URL.parse("en-US/docs", "https//developer.mozilla.org"), null);
+});
+
+test("Float16Array", () => {
+  const float16 = new Float16Array([42]);
+  assertEquals(float16[0], 42);
+  assertEquals(float16.length, 1);
+  assertEquals(float16.byteLength, 2);
+  assertEquals(float16.BYTES_PER_ELEMENT, 2);
+});


### PR DESCRIPTION
This is a follow-up for https://github.com/CheckerNetwork/zinnia/pull/717 where we upgraded Deno to the version adding these new APIs.

- `URL.parse()`
- `Float16Array`
- `Response.bytes()`

Parent issue:
- https://github.com/CheckerNetwork/zinnia/issues/676

