### PR TITLE
ci: use the latest Prettier version for linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,10 +177,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actionsx/prettier@3d9f7c3fa44c9cb819e68292a328d7f4384be206 # latest
-        with:
-          # prettier CLI arguments.
-          args: --check .
+      - uses: actions/setup-node@v4
+      - run: npx prettier --check .
 
   validate_pr_title:
     name: Validate PR title


### PR DESCRIPTION
The action `actionsx/prettier` hasn't been updated in years.

This commit changes the linting step to run `npx prettier`.

My goal is to fix the following CI failure that I cannot reproduce locally:
https://github.com/CheckerNetwork/zinnia/actions/runs/14446799004/job/40509253726?pr=730#step:3:9
