### PR TITLE
fix: source code paths relative to module root

### DIFF
--- a/daemon/tests/daemon_js_tests.rs
+++ b/daemon/tests/daemon_js_tests.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use tempfile::tempdir;
+use zinnia_runtime::AnyError;
+
+macro_rules! js_tests(
+    ( $name:ident ) => {
+    #[tokio::test]
+    async fn $name() -> Result<(), AnyError> {
+        run_js_test_file(&format!("{}.js", stringify!($name))).await?;
+        Ok(())
+    }
+    };
+);
+
+js_tests!(source_code_paths);
+
+async fn run_js_test_file(name: &str) -> Result<(), AnyError> {
+    let temp_root = tempdir().expect("cannot create temporary directory");
+    let cache_root = temp_root.path().join("cache");
+    let state_root = temp_root.path().join("state");
+
+    let mut mod_js = get_base_dir();
+    mod_js.push(name);
+    assert!(
+        mod_js.is_file(),
+        "test JS file not found: {}",
+        mod_js.display()
+    );
+
+    let bin = assert_cmd::cargo::cargo_bin("zinniad");
+    assert!(bin.is_file(), "zinniad not found: {}", bin.display());
+
+    // Create a command to start zinniad
+    let mut cmd = Command::new(bin);
+    cmd.env("NO_COLOR", "1")
+        .env("FIL_WALLET_ADDRESS", "f1test")
+        .env("STATION_ID", "a".repeat(88))
+        .env("CACHE_ROOT", cache_root.display().to_string())
+        .env("STATE_ROOT", state_root.display().to_string())
+        .args([&mod_js.as_os_str()]);
+
+    // Hide activity logs in JSON format
+    cmd.stdout(Stdio::null());
+
+    let exit_status = cmd.status()?;
+    assert!(
+        exit_status.success(),
+        "Expected zinniad to exit with success. Actual exit status: ${exit_status}"
+    );
+    Ok(())
+}
+
+fn get_base_dir() -> PathBuf {
+    let mut base_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    base_dir.push("tests");
+    base_dir.push("js");
+    base_dir
+}

--- a/daemon/tests/js/source_code_paths.js
+++ b/daemon/tests/js/source_code_paths.js
@@ -1,0 +1,20 @@
+import { test } from "zinnia:test";
+import { assertEquals, assertStringIncludes } from "zinnia:assert";
+
+// We must not leak the filesystem structure when the code is running inside a sandboxed environment.
+// Only path relative to the project root is available to the module.
+
+test("import.meta.filename is relative to the module root", () => {
+  const value = import.meta.filename.replace("\\", "/");
+  assertEquals(value, "/source_code_paths.js", "import.meta.filename");
+});
+
+test("import.meta.dirname is relative to the module root", () => {
+  const value = import.meta.dirname.replace("\\", "/");
+  assertEquals(value, "/", "import.meta.dirname");
+});
+
+test("stack trace contains file paths relative to the module root", () => {
+  const thisLine = new Error().stack.split("\n")[1];
+  assertStringIncludes(thisLine, "(file:///source_code_paths.js");
+});

--- a/runtime/module_loader.rs
+++ b/runtime/module_loader.rs
@@ -108,6 +108,8 @@ impl ModuleLoader for ZinniaModuleLoader {
                 ModuleLoaderError::from(JsErrorBox::generic(msg))
             })?;
 
+            let sandboxed_path: PathBuf;
+
             // Check that the module path is inside the module root directory
             if let Some(canonical_root) = &module_root {
                 // Resolve any symlinks inside the path to prevent modules from escaping our sandbox
@@ -120,19 +122,23 @@ impl ModuleLoader for ZinniaModuleLoader {
                     ModuleLoaderError::from(JsErrorBox::generic(msg))
                 })?;
 
-                if !canonical_module.starts_with(canonical_root) {
-                    let msg = format!(
-                        "Cannot import files outside of the module root directory.\n\
+                let relative_path =
+                    canonical_module.strip_prefix(canonical_root).map_err(|_| {
+                        let msg = format!(
+                            "Cannot import files outside of the module root directory.\n\
                          Root directory (canonical): {}\n\
                          Module file path (canonical): {}\
                          {}",
-                        canonical_root.display(),
-                        canonical_module.display(),
-                        details()
-                    );
-
-                    return Err(ModuleLoaderError::from(JsErrorBox::generic(msg)));
-                }
+                            canonical_root.display(),
+                            canonical_module.display(),
+                            details()
+                        );
+                        ModuleLoaderError::from(JsErrorBox::generic(msg))
+                    })?;
+                sandboxed_path = Path::new(r"/").join(relative_path).to_owned();
+                // sandboxed_path = PathBuf::from_str(r".").push(relative_path);
+            } else {
+                sandboxed_path = module_path.to_owned();
             };
 
             // Based on https://github.com/denoland/roll-your-own-javascript-runtime
@@ -211,10 +217,20 @@ impl ModuleLoader for ZinniaModuleLoader {
                 })?
                 .insert(spec_str.to_string(), code.clone());
 
+            let sandboxed_module_specifier = ModuleSpecifier::from_file_path(&sandboxed_path)
+                .map_err(|_| {
+                    let msg = format!(
+                        "Internal error: cannot convert relative path to module specifier: {}\n{}",
+                        sandboxed_path.display(),
+                        details()
+                    );
+                    ModuleLoaderError::from(JsErrorBox::generic(msg))
+                })?;
+
             let module = ModuleSource::new(
                 module_type,
                 ModuleSourceCode::String(code.into()),
-                &module_specifier,
+                &sandboxed_module_specifier,
                 None,
             );
 

--- a/runtime/tests/js/print_source_code_paths.js
+++ b/runtime/tests/js/print_source_code_paths.js
@@ -1,0 +1,3 @@
+console.log("import.meta.filename:", import.meta.filename);
+console.log("import.meta.dirname:", import.meta.dirname);
+console.log("error stack:", new Error().stack.split("\n")[1].trim());


### PR DESCRIPTION
We must not leak the filesystem structure when the code is running inside a sandboxed environment. Only path relative to the project root should be available to the module.

I discovered this issue while working on https://github.com/CheckerNetwork/zinnia/pull/735

Parent issue:
- https://github.com/CheckerNetwork/zinnia/issues/676
