### PR TITLE
fix: error stack traces in transpiled TypeScript

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 /runtime/vendored
 /runtime/js/vendored
 target
+/runtime/tests/js/typescript_fixtures/typescript_stack_trace.ts
 
 # Let's keep LICENSE.md in the same formatting as we use in other PL repositories
 LICENSE.md

--- a/runtime/module_loader.rs
+++ b/runtime/module_loader.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::rc::Rc;
 
 use deno_ast::{MediaType, ParseParams};
 use deno_core::anyhow::anyhow;
@@ -21,7 +23,9 @@ use deno_core::anyhow::Result;
 pub struct ZinniaModuleLoader {
     module_root: Option<PathBuf>,
     // Cache mapping file_name to source_code
-    code_cache: Arc<RwLock<HashMap<String, String>>>,
+    code_cache: Rc<RefCell<HashMap<String, String>>>,
+    // Cache mapping module_specifier string to source_map bytes
+    source_maps: Rc<RefCell<HashMap<String, Vec<u8>>>>,
 }
 
 impl ZinniaModuleLoader {
@@ -34,7 +38,8 @@ impl ZinniaModuleLoader {
 
         Ok(Self {
             module_root,
-            code_cache: Arc::new(RwLock::new(HashMap::new())),
+            code_cache: Rc::new(RefCell::new(HashMap::new())),
+            source_maps: Rc::new(RefCell::new(HashMap::new())),
         })
     }
 }
@@ -79,6 +84,7 @@ impl ModuleLoader for ZinniaModuleLoader {
         let module_root = self.module_root.clone();
         let maybe_referrer = maybe_referrer.cloned();
         let code_cache = self.code_cache.clone();
+        let source_maps = self.source_maps.clone();
         let module_load = async move {
             let spec_str = module_specifier.as_str();
 
@@ -177,6 +183,10 @@ impl ModuleLoader for ZinniaModuleLoader {
 
             let code = read_file_to_string(&module_path).await?;
 
+            code_cache
+                .borrow_mut()
+                .insert(spec_str.to_string(), code.clone());
+
             let code = if should_transpile {
                 let parsed = deno_ast::parse_module(ParseParams {
                     specifier: module_specifier.clone(),
@@ -187,7 +197,7 @@ impl ModuleLoader for ZinniaModuleLoader {
                     maybe_syntax: None,
                 })
                 .map_err(JsErrorBox::from_err)?;
-                parsed
+                let res = parsed
                     .transpile(
                         &deno_ast::TranspileOptions {
                             imports_not_used_as_values: deno_ast::ImportsNotUsedAsValues::Error,
@@ -195,21 +205,25 @@ impl ModuleLoader for ZinniaModuleLoader {
                             ..Default::default()
                         },
                         &Default::default(),
-                        &Default::default(),
+                        &deno_ast::EmitOptions {
+                            source_map: deno_ast::SourceMapOption::Separate,
+                            inline_sources: true,
+                            ..Default::default()
+                        },
                     )
                     .map_err(JsErrorBox::from_err)?
-                    .into_source()
-                    .text
+                    .into_source();
+
+                if let Some(source_map) = res.source_map {
+                    source_maps
+                        .borrow_mut()
+                        .insert(module_specifier.to_string(), source_map.into_bytes());
+                }
+
+                res.text
             } else {
                 code
             };
-
-            code_cache
-                .write()
-                .map_err(|_| {
-                    JsErrorBox::generic("Unexpected internal error: code_cache lock was poisoned")
-                })?
-                .insert(spec_str.to_string(), code.clone());
 
             let module = ModuleSource::new(
                 module_type,
@@ -224,9 +238,16 @@ impl ModuleLoader for ZinniaModuleLoader {
         ModuleLoadResponse::Async(module_load.boxed_local())
     }
 
+    fn get_source_map(&self, specifier: &str) -> Option<Cow<[u8]>> {
+        self.source_maps
+            .borrow()
+            .get(specifier)
+            .map(|v| v.clone().into())
+    }
+
     fn get_source_mapped_source_line(&self, file_name: &str, line_number: usize) -> Option<String> {
         log::debug!("get_source_mapped_source_line {file_name}:{line_number}");
-        let code_cache = self.code_cache.read().ok()?;
+        let code_cache = self.code_cache.borrow();
         let code = code_cache.get(file_name)?;
 
         // Based on Deno cli/module_loader.rs

--- a/runtime/tests/js/typescript_fixtures/typescript_stack_trace.ts
+++ b/runtime/tests/js/typescript_fixtures/typescript_stack_trace.ts
@@ -10,5 +10,5 @@ interface User {
 // between the TypeScript original and the transpiled code.
 //
 // Throw the error so that the test can verify source code line & column numbers
-// in the stack trace frames but also the line throwing the exception.
+// in the stack trace frames but also the source code of the line throwing the exception.
 const error: Error = new Error(); throw error;

--- a/runtime/tests/js/typescript_fixtures/typescript_stack_trace.ts
+++ b/runtime/tests/js/typescript_fixtures/typescript_stack_trace.ts
@@ -1,0 +1,14 @@
+// This TypeScript-only block of code is removed during transpilation. A naive solution that removes
+// the TypeScript code instead of replacing it with whitespace and does not apply source maps to error
+// stack traces will lead to incorrect line numbers in error stack traces.
+interface User {
+  name: string;
+  email: string;
+}
+
+// The part `: Error` changes the source column number
+// between the TypeScript original and the transpiled code.
+//
+// Throw the error so that the test can verify source code line & column numbers
+// in the stack trace frames but also the line throwing the exception.
+const error: Error = new Error(); throw error;

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -110,7 +110,7 @@ async fn typescript_stack_trace_test() -> Result<(), AnyError> {
         let cwd_url = ModuleSpecifier::from_file_path(std::env::current_dir().unwrap()).unwrap();
         let actual_error = actual_error.replace(cwd_url.as_str(), "file:///project-root");
         // Normalize line endings to Unix style (LF only)
-        let actual_error = actual_error.replace("\r\n", "\n")
+        let actual_error = actual_error.replace("\r\n", "\n");
 
         let expected_error = r#"
 Uncaught (in promise) Error

--- a/runtime/tests/runtime_integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests.rs
@@ -109,6 +109,8 @@ async fn typescript_stack_trace_test() -> Result<(), AnyError> {
         // Replace current working directory in stack trace file paths with a fixed placeholder
         let cwd_url = ModuleSpecifier::from_file_path(std::env::current_dir().unwrap()).unwrap();
         let actual_error = actual_error.replace(cwd_url.as_str(), "file:///project-root");
+        // Normalize line endings to Unix style (LF only)
+        let actual_error = actual_error.replace("\r\n", "\n")
 
         let expected_error = r#"
 Uncaught (in promise) Error


### PR DESCRIPTION
This is a follow-up for #717, where we added TypeScript transpilation but did not test how it works in practice.

The implementation is based on this Deno example:
https://github.com/denoland/deno_core/blob/0.343.0/core/examples/ts_module_loader.rs

Example code:

```ts
interface User {
  name: string;
  email: string;
}

const err: Error = new Error("boom!"); throw err;
```

Deno output:

```
error: Uncaught (in promise) Error: boom!
const err: Error = new Error("boom!"); throw err;
                   ^
    at file:///project/x.ts:6:20
```

Zinnia before this change - notice the missing `: Error` snippet and wrong source code line & column numbers:

```
error: Uncaught (in promise) Error: boom!
const err = new Error("boom!");
            ^
    at file:///project/x.ts:1:13
```

Zinnia after this change (same output as from Deno):

```
error: Uncaught (in promise) Error: boom!
const err: Error = new Error("boom!"); throw err;
                   ^
    at file:///project/x.ts:6:20
```

Links:
- https://github.com/CheckerNetwork/zinnia/issues/676
- https://github.com/CheckerNetwork/zinnia/issues/30

Related:
- https://github.com/denoland/deno/issues/4499
- https://github.com/denoland/deno_core/pull/819

