### PR TITLE
ci: fix Linux release builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: Continuous integration
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
-      - none
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: Continuous integration
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
-      - main
+      - none
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     # attach the release artifacts to GHA workflow run Summary page, where you can download them for
     # inspection.
     # REMEMBER TO REVERT BACK THE CHANGE BEFORE LANDING YOUR PULL REQUEST!
-    # branches: ['*']
+    branches: ["*"]
 
 env:
   CARGO_INCREMENTAL: 0
@@ -57,17 +57,17 @@ jobs:
           #   name: linux-arm64-musl.tar.gz
           #   builder: cross
 
-          - target: x86_64-apple-darwin
-            os: macos-13
-            name: macos-x64.zip
+          # - target: x86_64-apple-darwin
+          #   os: macos-13
+          #   name: macos-x64.zip
 
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            name: macos-arm64.zip
+          # - target: aarch64-apple-darwin
+          #   os: macos-latest
+          #   name: macos-arm64.zip
 
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            name: windows-x64.zip
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
+          #   name: windows-x64.zip
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,7 @@ jobs:
       - name: Setup | Cross
         if: ${{ matrix.builder == 'cross' }}
         run: |
-          curl -L https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz -o /tmp/cross.tgz
-          tar xzf /tmp/cross.tgz -C ~/.cargo/bin
+          cargo install cross --git https://github.com/cross-rs/cross --rev a6cffa067e9f7d74433523c6d0abe28d9defedd4
           cross --version
 
       # When debugging this workflow, cache the build artefacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     # attach the release artifacts to GHA workflow run Summary page, where you can download them for
     # inspection.
     # REMEMBER TO REVERT BACK THE CHANGE BEFORE LANDING YOUR PULL REQUEST!
-    branches: ["*"]
+    # branches: ['*']
 
 env:
   CARGO_INCREMENTAL: 0
@@ -57,17 +57,17 @@ jobs:
           #   name: linux-arm64-musl.tar.gz
           #   builder: cross
 
-          # - target: x86_64-apple-darwin
-          #   os: macos-13
-          #   name: macos-x64.zip
+          - target: x86_64-apple-darwin
+            os: macos-13
+            name: macos-x64.zip
 
-          # - target: aarch64-apple-darwin
-          #   os: macos-latest
-          #   name: macos-arm64.zip
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            name: macos-arm64.zip
 
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-latest
-          #   name: windows-x64.zip
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: windows-x64.zip
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Upgrade `cross` to the current latest version in git to fix the following build error:

```
 = note: /target/x86_64-unknown-linux-gnu/release/deps/libv8-2ad472a53f497811.rlib(wasm-objects.o): In function `v8::internal::WasmMemoryMapDescriptor::NewFromAnonymous(v8::internal::Isolate*, unsigned long)':
          ./../../../../v8/src/wasm/wasm-objects.cc:1183: undefined reference to `memfd_create'
```

This should fix the failing release builds as seen e.g. here: https://github.com/CheckerNetwork/zinnia/actions/runs/14613159941/job/40995245251

References:
- https://github.com/CheckerNetwork/zinnia/pull/200
- https://github.com/cross-rs/cross/issues/1510