### PR TITLE
docs: describe how to use WASM modules

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -33,6 +33,7 @@ See [example modules](../examples) for more advanced examples.
 ## Table of Contents
 
 - [Importing JavaScript Modules](#importing-javascript-modules)
+- [Working with WebAssembly](#working-with-webassembly)
 - [Platform APIs](#platform-apis)
 - [Testing Guide](#testing-guide)
 
@@ -84,6 +85,18 @@ import { format } from "../lib.js";
 // This will be rejected
 import * as code from "../../other/code.js";
 ```
+
+## Working with WebAssembly
+
+Zinnia can directly import functions exported by WebAssembly modules.
+
+```js
+import { add } from "./math.wasm";
+console.log(add(1, 2));
+```
+
+We are looking for feedback from the community to improve the WASM support. Join the discussion on
+GitHub in [zinnia#74](https://github.com/CheckerNetwork/zinnia/issues/74).
 
 ## Platform APIs
 


### PR DESCRIPTION
This is a follow-up for https://github.com/CheckerNetwork/zinnia/pull/722 to enable subnet builders to experiment with WebAssembly code and give us feedback on what to improve.

Links:
- https://github.com/CheckerNetwork/zinnia/issues/706
- https://github.com/CheckerNetwork/zinnia/issues/74
