### PR TITLE
chore: add `createHttpClient` to Zinnia namespace

### DIFF
--- a/docs/building-modules.md
+++ b/docs/building-modules.md
@@ -352,6 +352,12 @@ The version of Zinnia runtime, e.g. `"0.11.0"`.
 
 The version of V8 engine, e.g. `"11.5.150.2"`.
 
+#### `Zinnia.createHttpClient`
+
+Create a custom HttpClient to use with fetch.
+
+See [Deno.createHttpClient() docs](https://docs.deno.com/api/deno/~/Deno.createHttpClient) for more details.
+
 ## Testing Guide
 
 Zinnia provides lightweight tooling for writing and running automated tests.

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -5,6 +5,8 @@ import { op_info_activity, op_error_activity, op_job_completed, op_zinnia_log } 
 
 import { inspect } from "ext:deno_console/01_console.js";
 import { versions } from "ext:zinnia_runtime/01_version.ts";
+import * as httpClient from "ext:deno_fetch/22_http_client.js";
+
 
 const zinniaNs = ObjectCreate(null);
 
@@ -19,6 +21,7 @@ ObjectDefineProperties(zinniaNs, {
   jobCompleted: core.propReadOnly(reportJobCompleted),
   versions: core.propReadOnly(versions),
   inspect: core.propReadOnly(inspect),
+  createHttpClient: core.propWritable(httpClient.createHttpClient),
 });
 
 function reportInfoActivity(msg) {

--- a/runtime/js/90_zinnia_apis.js
+++ b/runtime/js/90_zinnia_apis.js
@@ -7,7 +7,6 @@ import { inspect } from "ext:deno_console/01_console.js";
 import { versions } from "ext:zinnia_runtime/01_version.ts";
 import * as httpClient from "ext:deno_fetch/22_http_client.js";
 
-
 const zinniaNs = ObjectCreate(null);
 
 const activityApi = ObjectCreate(null);

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -27,7 +27,6 @@ import * as messagePort from "ext:deno_web/13_message_port.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
 import * as abortSignal from "ext:deno_web/03_abort_signal.js";
-import * as httpClient from "ext:deno_fetch/22_http_client.js";
 
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
 
@@ -119,7 +118,6 @@ const windowOrWorkerGlobalScope = {
   structuredClone: core.propWritable(messagePort.structuredClone),
   // Branding as a WebIDL object
   [webidl.brand]: core.propNonEnumerable(webidl.brand),
-  createHttpClient: core.propWritable(httpClient.createHttpClient),
 };
 
 const mainRuntimeGlobalProperties = {

--- a/runtime/js/98_global_scope.js
+++ b/runtime/js/98_global_scope.js
@@ -27,6 +27,7 @@ import * as messagePort from "ext:deno_web/13_message_port.js";
 import * as webidl from "ext:deno_webidl/00_webidl.js";
 import { DOMException } from "ext:deno_web/01_dom_exception.js";
 import * as abortSignal from "ext:deno_web/03_abort_signal.js";
+import * as httpClient from "ext:deno_fetch/22_http_client.js";
 
 import * as globalInterfaces from "ext:deno_web/04_global_interfaces.js";
 
@@ -118,6 +119,7 @@ const windowOrWorkerGlobalScope = {
   structuredClone: core.propWritable(messagePort.structuredClone),
   // Branding as a WebIDL object
   [webidl.brand]: core.propNonEnumerable(webidl.brand),
+  createHttpClient: core.propWritable(httpClient.createHttpClient),
 };
 
 const mainRuntimeGlobalProperties = {

--- a/runtime/tests/js/http_tests.js
+++ b/runtime/tests/js/http_tests.js
@@ -1,0 +1,12 @@
+import { test } from "zinnia:test";
+import { assert, assertEquals } from "zinnia:assert";
+
+test("Zinnia.createHttpClient", async () => {
+  const client = Zinnia.createHttpClient({
+    localAddress: "127.0.0.2",
+  });
+  assert(client);
+  const res = await fetch("https://example.com/", { client });
+  assertEquals(res.status, 200);
+});
+

--- a/runtime/tests/js/http_tests.js
+++ b/runtime/tests/js/http_tests.js
@@ -9,4 +9,3 @@ test("Zinnia.createHttpClient", async () => {
   const res = await fetch("https://example.com/", { client });
   assertEquals(res.status, 200);
 });
-


### PR DESCRIPTION
This PR adds [createHttpClient](https://docs.deno.com/api/deno/~/Deno.createHttpClient) function to Zinnia namespace. 

Currently we're using a default http client that Deno runtime [creates and reuses for each request](https://github.com/denoland/deno/blob/0f6d515c91a486cc30acd34d1237f7fdaf95df8c/ext/fetch/lib.rs#L526-L531). 

Adding this function to a global runtime would enable us to create a new http client on per request basis and potentially enable proxy rotation for each request. 